### PR TITLE
Add a version check action to run with linting and ensure we bumped the version

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -24,3 +24,9 @@ jobs:
         run: |
           pip install mypy types-requests pandas-stubs typing_extensions
           mypy -p eedl --enable-incomplete-feature=Unpack
+
+  Version-Check:
+      runs-on: ubuntu-latest
+      steps:
+        python -m pip install requests
+        python -c "import requests;latest=requests.get('https://pypi.org/pypi/eedl/json').json()['info']['version'];import eedl;assert eedl.__version__ > latest"

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -24,9 +24,3 @@ jobs:
         run: |
           pip install mypy types-requests pandas-stubs typing_extensions
           mypy -p eedl --enable-incomplete-feature=Unpack
-
-  Version-Check:
-      runs-on: ubuntu-latest
-      steps:
-        python -m pip install requests
-        python -c "import requests;latest=requests.get('https://pypi.org/pypi/eedl/json').json()['info']['version'];import eedl;assert eedl.__version__ > latest"

--- a/.github/workflows/version-bump-check.yml
+++ b/.github/workflows/version-bump-check.yml
@@ -12,5 +12,16 @@ jobs:
   Version-Check:
       runs-on: ubuntu-latest
       steps:
-        python -m pip install requests
-        python -c "import requests;latest=requests.get('https://pypi.org/pypi/eedl/json').json()['info']['version'];import eedl;assert eedl.__version__ > latest"
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Set Up Python Ubuntu
+        uses: actions/setup-python@v4
+        if: matrix.os ==  'ubuntu-latest'
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Check version is increased
+        run: |
+          python -m pip install requests
+          python -c "import requests;latest=requests.get('https://pypi.org/pypi/eedl/json').json()['info']['version'];import eedl;assert eedl.__version__ > latest"

--- a/.github/workflows/version-bump-check.yml
+++ b/.github/workflows/version-bump-check.yml
@@ -1,0 +1,16 @@
+name: Ensure we bumped the version of the package
+
+on:
+  push:
+    branches:
+      - 'release'
+  pull_request:
+    branches:
+      - 'release'
+
+jobs:
+  Version-Check:
+      runs-on: ubuntu-latest
+      steps:
+        python -m pip install requests
+        python -c "import requests;latest=requests.get('https://pypi.org/pypi/eedl/json').json()['info']['version'];import eedl;assert eedl.__version__ > latest"

--- a/.github/workflows/version-bump-check.yml
+++ b/.github/workflows/version-bump-check.yml
@@ -1,4 +1,4 @@
-name: Ensure we bumped the version of the package
+name: Version bump
 
 on:
   push:


### PR DESCRIPTION
Adam, this is a pretty simple action. The code should run (and fail) now because we lack a published release at the moment and then it will fail in the future unless we bump the version.

I think I'm going to update this by splitting it from linting so that it can only run on PRs to release and not cause linting to fail elsewhere